### PR TITLE
Handle API errors using ApiRequestError

### DIFF
--- a/lib/shipstation.rb
+++ b/lib/shipstation.rb
@@ -63,12 +63,6 @@ module Shipstation
 
       params.except!(:username, :password)
 
-      defined? method or raise(
-        ArgumentError, "Request method has not been specified"
-      )
-      defined? resource or raise(
-        ArgumentError, "Request resource has not been specified"
-      )
       if method == :get
         headers = {:accept => :json, content_type: :json}.merge({params: params})
         payload = nil

--- a/lib/shipstation.rb
+++ b/lib/shipstation.rb
@@ -88,9 +88,5 @@ module Shipstation
         str_response.blank? ? '' : JSON.parse(str_response)
       end
     end
-
-    def datetime_format datetime
-      datetime.strftime("%Y-%m-%d %T")
-    end
   end
 end


### PR DESCRIPTION
Fixes #27

This PR is being used in production to make it possible to read the X-Rate-Limit-Reset response header in order to know how long to delay subsequent requests if the rate limit has been hit.

Unlike the previous version of ApiRequestError, the response body is passed up to ShipstationError as a standard error. This is to avoid having a different, and unexpected, interface to StandardError.

It also removes the calls to `defined?` in the `request` method. While I'm happy to have an edge case explained, I can't see any situation where method parameters would not be defined. Even if `nil` was passed as an argument to the method, they variable would still be defined, simply with a `nil` value.